### PR TITLE
Fix max message size for gRPC call

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var maxMessageSize = 1024 * 1024 * 1024
+var maxMessageSize = 200 * 1024 * 1024 // 200MB
 
 // Generates the gRPC lightning client∏
 func CreateLightningClient(lndConnectParams lndconnect.LndConnectParams) (lnrpc.LightningClient, *grpc.ClientConn, error) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+var maxMessageSize = 1024 * 1024 * 1024
+
 // Generates the gRPC lightning client∏
 func CreateLightningClient(lndConnectParams lndconnect.LndConnectParams) (lnrpc.LightningClient, *grpc.ClientConn, error) {
 	creds, err := generateCredentials(lndConnectParams.Cert)
@@ -71,8 +73,11 @@ func CreateNodeGuardClient(nodeGuardEndpoint string) (nodeguard.NodeGuardService
 }
 
 // generates the gRPC connection based on the node endpoint and the credentials
-func getConn(nodeEndpoint string, creds credentials.TransportCredentials) (*grpc.ClientConn, error) {
-	conn, err := grpc.Dial(nodeEndpoint, grpc.WithTransportCredentials(creds),
+func getConn(gRPCEndpoint string, creds credentials.TransportCredentials) (*grpc.ClientConn, error) {
+	conn, err := grpc.Dial(gRPCEndpoint, grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(maxMessageSize)),
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()))
 


### PR DESCRIPTION
- feat(rpc.go): increase maxMessageSize to 1GB to handle larger data refactor(rpc.go): rename nodeEndpoint to gRPCEndpoint for better clarity feat(rpc.go): add grpc.WithDefaultCallOptions to set max receive and send message size, improving data handling capabilities
- fix(rpc.go): reduce maxMessageSize from 1GB to 200MB to optimize memory usage and improve performance
