### PR TITLE
Delete only metrics for channels that are no longer in the list

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,4 +1,5 @@
 set positional-arguments
+set fallback := true
 
 fmt:
     go fmt github.com/Elenpay/...


### PR DESCRIPTION
This has the same result in prometheus as the previous code, let's see if datadog works with this.

Only edge case is that if the remote node doesn't exist anymore metrics won't be deleted because we need the node alias for removing the label. This can be done by saving in memory a struct with all the current labels info for channels, but it will need a not small refactor, since the Channels struct is used in a lot of places.

Feel free to hold this and do the refactor instead. I'll create a ticket