### PR TITLE
Fix tracing sampling overriding the env var

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -113,6 +113,10 @@ func init() {
 	rootCmd.Flags().Float64("backoffLimit", 0.1, "Limit coefficient of the backoff")
 	viper.BindPFlag("backoffLimit", rootCmd.Flags().Lookup("backoffLimit"))
 
+	// Limit fees for swaps in % of the amount
+	rootCmd.Flags().Float64("limitFees", 0.01, "Limit fees for swaps e.g. 0.01")
+	viper.BindPFlag("limitFees", rootCmd.Flags().Lookup("limitFees"))
+
 	//Now we set the global vars
 
 	pollingInterval = viper.GetDuration("pollingInterval")
@@ -123,6 +127,7 @@ func init() {
 	retries = viper.GetInt("retriesBeforeBackoff")
 	backoffCoefficient = viper.GetFloat64("backoffCoefficient")
 	backoffLimit = viper.GetFloat64("backoffLimit")
+	limitFees = viper.GetFloat64("limitFees")
 
 	//Set log level and format
 

--- a/liquidator.go
+++ b/liquidator.go
@@ -35,6 +35,7 @@ var (
 	retries            int
 	backoffCoefficient float64
 	backoffLimit       float64
+	limitFees          float64
 )
 
 // Entrypoint of liquidator main logic

--- a/provider/loop_provider.go
+++ b/provider/loop_provider.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/Elenpay/liquidator/errors"
@@ -60,7 +62,8 @@ func (l *LoopProvider) RequestSubmarineSwap(ctx context.Context, request Submari
 		return SubmarineSwapResponse{}, err
 	}
 
-	limitFees := viper.GetFloat64("limitFees")
+	limitFeesStr := os.Getenv("LIMITFEES")
+	limitFees, err := strconv.ParseFloat(limitFeesStr, 64)
 	sumFees := quote.SwapFeeSat + quote.HtlcPublishFeeSat
 
 	if sumFees > int64(float64(request.SatsAmount)*limitFees) {

--- a/provider/loop_provider.go
+++ b/provider/loop_provider.go
@@ -231,8 +231,17 @@ func (l *LoopProvider) RequestReverseSubmarineSwap(ctx context.Context, request 
 	})
 
 	if err != nil {
-
 		log.Errorf("error getting quote for reverse submarine swap: %s", err)
+		return ReverseSubmarineSwapResponse{}, err
+	}
+
+	limitFeesStr := os.Getenv("LIMITFEES")
+	limitFees, err := strconv.ParseFloat(limitFeesStr, 64)
+	sumFees := quote.SwapFeeSat + quote.HtlcSweepFeeSat + quote.PrepayAmtSat
+
+	if sumFees > int64(float64(request.SatsAmount)*limitFees) {
+		err := fmt.Errorf("swap fees are greater than max limit fees")
+		log.Error(err)
 		return ReverseSubmarineSwapResponse{}, err
 	}
 

--- a/provider/loop_provider.go
+++ b/provider/loop_provider.go
@@ -60,6 +60,15 @@ func (l *LoopProvider) RequestSubmarineSwap(ctx context.Context, request Submari
 		return SubmarineSwapResponse{}, err
 	}
 
+	limitFees := viper.GetFloat64("limitFees")
+	sumFees := quote.SwapFeeSat + quote.HtlcPublishFeeSat
+
+	if sumFees > int64(float64(request.SatsAmount)*limitFees) {
+		err := fmt.Errorf("swap fees are greater than max limit fees")
+		log.Error(err)
+		return SubmarineSwapResponse{}, err
+	}
+
 	//Get limits
 	limits := getInLimits(quote)
 

--- a/provider/loop_provider_test.go
+++ b/provider/loop_provider_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/hex"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ func TestLoopProvider_RequestSubmarineSwap(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	os.Setenv("LIMITFEES", "0.1")
 
 	//Mock lightning swapClient GetLoopInQuote and LoopIn methods to return fake data
 	swapClient := NewMockSwapClientClient(ctrl)

--- a/telemetry.go
+++ b/telemetry.go
@@ -118,7 +118,6 @@ func initTracer(ctx context.Context) (*trace.TracerProvider, error) {
 
 	otel.SetTracerProvider(
 		trace.NewTracerProvider(
-			trace.WithSampler(trace.AlwaysSample()),
 			trace.WithResource(res),
 			trace.WithSpanProcessor(trace.NewBatchSpanProcessor(exp)),
 		),


### PR DESCRIPTION
- fix: set max limit for fees
- fix(loop_provider.go): change limitFees variable to read from environment variable LIMITFEES instead of using viper to improve flexibility and configuration options test(loop_provider_test.go): set LIMITFEES environment variable to "0.1" for testing purposes
- feat: limit of fees in loopout
- fix(telemetry.go): remove AlwaysSample() from TracerProvider to reduce unnecessary tracing overhead
