### PR TITLE
Disable blocking swaps on quote fees limits for L1+services fees (experiment)

### DIFF
--- a/provider/loop_provider.go
+++ b/provider/loop_provider.go
@@ -246,9 +246,7 @@ func (l *LoopProvider) RequestReverseSubmarineSwap(ctx context.Context, request 
 	maximumFeesAllowed := int64(float64(request.SatsAmount) * limitQuoteFees)
 
 	if sumFees > maximumFeesAllowed {
-		err := fmt.Errorf("swap quote fees (L1+Service estimation fees) are greater than max limit fees, quote fees: %d, maximum fees allowed: %d", sumFees, maximumFeesAllowed)
-		log.Error(err)
-		return ReverseSubmarineSwapResponse{}, err
+		log.Warnf("swap quote fees (L1+Service estimation fees) are greater than max limit fees, quote fees: %d, maximum fees theoretically allowed: %d", sumFees, maximumFeesAllowed)
 	}
 
 	//Max swap routing fee (L2 fees) is a percentage of the swap amount


### PR DESCRIPTION
This pull request disables blocking swaps on quote fees limits for L1+services fees. It updates the code to log a warning message instead of returning an error when the swap quote fees exceed the maximum limit fees. This change is part of an experiment to test the behavior of the system.